### PR TITLE
fix(webui): Package name not displayed in game delete dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # idea
 /.idea
+
+# Darwin
+/.DS_Store

--- a/webui/src/locales/en/common.json
+++ b/webui/src/locales/en/common.json
@@ -34,6 +34,6 @@
   "tab_games": "Game List",
   "tab_power": "Modes",
   "delete_game": "Delete Game",
-  "delete_game_confirm": "Are you sure you want to delete {game}? This action cannot be undone.",
+  "delete_game_confirm": "Are you sure you want to delete {{game}}? This action cannot be undone.",
   "delete": "Delete"
 }

--- a/webui/src/locales/zh/common.json
+++ b/webui/src/locales/zh/common.json
@@ -34,6 +34,6 @@
   "tab_games": "游戏列表",
   "tab_power": "模式",
   "delete_game": "删除游戏",
-  "delete_game_confirm": "您确定要删除 {game} 吗？此操作无法撤消。",
+  "delete_game_confirm": "您确定要删除 {{game}} 吗？此操作无法撤消。",
   "delete": "删除"
 }


### PR DESCRIPTION
Fixed package name not displayed in the game delete dialog:

<img width="1469" alt="image" src="https://github.com/user-attachments/assets/c24c2457-5948-4c57-96c3-05fd980d5590" />

Also added .DS_Store from MacOS Finder to .gitignore

This should fix all the problems form the webui, thanks @shadow3aaa 
