### PR TITLE
build: enable mimalloc features no_thp and override

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ quick-xml = { version = "0.38.4", features = ["serialize"] }
 mlua = { version = "0.11.4", features = ["luajit", "vendored", "error-send"] }
 frame-analyzer = "0.3.4"
 dumpsys-rs = { git = "https://github.com/shadow3aaa/dumpsys-rs" }
-mimalloc = "0.1.48"
+mimalloc = { version = "0.1.48", features = ["no_thp", "override"] }
 num_cpus = "1.17.0"
 nix = { version = "0.30.1", features = ["sched"] }
 


### PR DESCRIPTION
对于延迟敏感型任务，最好是关闭thp降低抖动
- add "no_thp" to disable transparent huge pages for lower memory latency
- add "override" to let mimalloc replace the system allocator globally