### PR TITLE
fix: improve robustness when $DIR disappears unexpectedly

### DIFF
--- a/module/service.sh
+++ b/module/service.sh
@@ -21,11 +21,22 @@ DIR=/sdcard/Android/fas-rs
 MERGE_FLAG=$DIR/.need_merge
 LOG=$DIR/fas_log.txt
 
+wait_until_login() {
+    # in case of /data encryption is disabled
+    while [ "$(getprop sys.boot_completed)" != "1" ]; do sleep 1; done
+    # we doesn't have the permission to rw "/sdcard" before the user unlocks the screen
+    until [ -d /sdcard/Android ]; do sleep 1; done
+}
+
+wait_until_login
+
 sh $MODDIR/vtools/init_vtools.sh $(realpath $MODDIR/module.prop)
 
 resetprop fas-rs-installed true
 
 until [ -d $DIR ]; do
+	mkdir $DIR
+	cp $MODDIR/games.toml $DIR/games.toml
 	sleep 1
 done
 


### PR DESCRIPTION
/sdcard/Android/fas-rs目录有时候玄学消失，增加一点健壮性

In some edge cases, the $DIR (/sdcard/Android/fas-rs) may be removed after boot, causing the script to hang indefinitely. This patch adds a wait_until_login function to ensure proper timing and proactively recreates the directory and copies games.toml if it goes missing.

- Add wait_until_login to handle early boot timing issues
- Ensure $DIR exists by creating it and copying games.toml
- Prevent infinite loop when directory is absent