### PR TITLE
fix(scheduler): resolve all mFocusedApp PIDs for multi-display devices

### DIFF
--- a/src/framework/scheduler/topapp.rs
+++ b/src/framework/scheduler/topapp.rs
@@ -41,21 +41,32 @@ impl WindowsInfo {
     }
 
     fn parse_top_app(dump: &str) -> Vec<i32> {
-        let Some(focused_app_line) = dump
+        // Some devices (e.g. phones with a back/secondary screen, foldables)
+        // report more than one `mFocusedApp` line in the window dump.
+        // Collect every one and resolve a PID for each so multi-display
+        // setups are handled correctly.
+        let packages: Vec<&str> = dump
             .lines()
-            .find(|line| line.trim().starts_with("mFocusedApp="))
-        else {
-            return Vec::new();
-        };
-        let Some(package_name) = Self::extract_package_name(focused_app_line) else {
-            return Vec::new();
-        };
+            .filter(|line| line.trim().starts_with("mFocusedApp="))
+            .filter_map(Self::extract_package_name)
+            .collect();
 
-        // Try modern parser, if it fails, fall back to legacy parser.
-        let pid = Self::parse_a16_format(dump, package_name)
-            .or_else(|| Self::parse_a15_format(dump, package_name));
+        if packages.is_empty() {
+            return Vec::new();
+        }
 
-        pid.map_or_else(Vec::new, |p| vec![p])
+        let mut pids = Vec::new();
+        for pkg in packages {
+            let Some(pid) = Self::parse_a16_format(dump, pkg)
+                .or_else(|| Self::parse_a15_format(dump, pkg))
+            else {
+                continue;
+            };
+            if !pids.contains(&pid) {
+                pids.push(pid);
+            }
+        }
+        pids
     }
 
     fn extract_package_name(line: &str) -> Option<&str> {


### PR DESCRIPTION
对于拥有多个焦点窗口/有背屏的设备（如小米17Pro/ProMax），窗口dump信息中会报告多行`mFocusedApp`。此前`find()`调用仅保留第一条记录，而在这类设备上，第一条记录通常是背屏/副屏桌面而非实际游戏，这导致fas-rs始终无法附加分析器，静默失败，不会捕获到游戏并启动。

下面是小米17Pro在HyperOS 3.0.315.0运行原神时mFocusedApp的数据：
```shell
adb shell "dumpsys window visible-apps" | grep -E "mFocusedApp|mResumedActivity"
  mFocusedApp=ActivityRecord{237241408 u0 com.xiaomi.subscreencenter/.SubScreenLauncher t4}
  mFocusedApp=ActivityRecord{221032814 u0 com.miHoYo.Yuanshen/com.miHoYo.GetMobileInfo.MainActivity t13}
``` 

现需遍历所有`mFocusedApp`行，并为每行解析对应的PID，以便正确处理多显示器场景。

已在小米17Pro上测试，现在可以正常获取到游戏进程。